### PR TITLE
refactor: hono-openapi で実装 & Scalarで表示

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -15,15 +15,18 @@
   "dependencies": {
     "@azure/functions": "^4.0.0",
     "@hono/node-server": "^1.17.1",
-    "@hono/zod-openapi": "^1.1.0",
+    "@hono/zod-validator": "^0.7.2",
     "@langchain/core": "^0.3.66",
     "@langchain/google-genai": "^0.2.16",
     "@marplex/hono-azurefunc-adapter": "^1.0.1",
+    "@scalar/hono-api-reference": "^0.9.13",
     "dotenv": "^17.2.1",
     "hono": "^4.8.4",
+    "hono-openapi": "0.5.0-rc.1",
     "langchain": "^0.3.30",
     "tsx": "^4.20.3",
-    "zod": "^4.0.14"
+    "zod": "^4.0.17",
+    "zod-openapi": "^5.3.1"
   },
   "devDependencies": {
     "@types/node": "18.x",

--- a/apps/backend/src/ai/createObject.ts
+++ b/apps/backend/src/ai/createObject.ts
@@ -1,80 +1,63 @@
-import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
+import { Hono } from "hono";
+import { describeRoute, resolver, validator } from "hono-openapi";
+import { z } from "zod";
 import { create3DObjectFromMessage } from "../util/create3DObject";
-import { AiOutputSchema, ConversationHistorySchema } from "./schemas";
+import {
+  AiInputSchema,
+  AiOutputSchema,
+  ConversationHistorySchema,
+} from "./schemas";
 
 const ErrorSchema = z.object({
-  message: z.string().openapi({ example: "エラーメッセージ" }),
-});
-const createObjectRoute = createRoute({
-  method: "get",
-  path: "/createObject",
-  request: {
-    query: z.object({
-      userInput: z.string().min(1).openapi({
-        example: "かわいい家つくって",
-        description: "ユーザー入力コメント",
-      }),
-      history: z
-        .string()
-        .optional()
-        .openapi({
-          example: JSON.stringify([
-            { role: "user", content: "かわいい家つくって" },
-            {
-              role: "assistant",
-              content:
-                '{"chat": "かわいい家ができました！","name": "かわいい家","parts":[{~}]}',
-            },
-          ]),
-          description: "会話履歴(JSON文字列)",
-        }),
-    }),
-  },
-  responses: {
-    200: {
-      description: "3Dオブジェクト生成結果",
-      content: { "application/json": { schema: AiOutputSchema } },
-    },
-    400: {
-      description: "バリデーションエラー",
-      content: { "application/json": { schema: ErrorSchema } },
-    },
-    500: {
-      description: "サーバーエラー",
-      content: { "application/json": { schema: ErrorSchema } },
-    },
-  },
+  message: z.string().meta({ example: "エラーメッセージ" }),
 });
 
-const app = new OpenAPIHono();
+const app = new Hono();
 
-app.openapi(createObjectRoute, async (c) => {
-  const { userInput, history } = c.req.valid("query");
-  let parsedHistory: ConversationHistorySchema = [];
-  if (history) {
-    const raw = JSON.parse(history);
-    const result = ConversationHistorySchema.safeParse(raw);
-    if (!result.success) {
-      return c.json({ message: "会話履歴の解析に失敗しました" }, 400);
+app.get(
+  "/createObject",
+  describeRoute({
+    description: "AIオブジェクト生成エンドポイント",
+    tags: ["AI"],
+    responses: {
+      200: {
+        description: "3Dオブジェクト生成結果",
+        content: { "application/json": { schema: resolver(AiOutputSchema) } },
+      },
+      400: {
+        description: "バリデーションエラー",
+        content: { "application/json": { schema: resolver(ErrorSchema) } },
+      },
+      500: {
+        description: "サーバーエラー",
+        content: { "application/json": { schema: resolver(ErrorSchema) } },
+      },
+    },
+  }),
+  validator("query", AiInputSchema),
+  async (c) => {
+    const { userInput, history } = c.req.valid("query");
+    let parsedHistory: ConversationHistorySchema = [];
+    if (history) {
+      const raw = JSON.parse(history);
+      const result = ConversationHistorySchema.safeParse(raw);
+      if (!result.success) {
+        return c.json({ message: "会話履歴の解析に失敗しました" }, 400);
+      }
+      parsedHistory = result.data;
     }
-    parsedHistory = result.data;
-  }
 
-  try {
-    const data = await create3DObjectFromMessage(
-      userInput,
-      JSON.stringify(parsedHistory),
-    );
-    return c.json(data, 200);
-  } catch (e) {
-    const message = e instanceof Error ? e.message : "3Dオブジェクト生成失敗";
-    return c.json({ message }, 500);
-  }
-});
-
-app.doc("/createObject.json", {
-  openapi: "3.0.0",
-  info: { title: "3Dオブジェクト生成API", version: "1.0.0" },
-});
+    try {
+      const data = await create3DObjectFromMessage(
+        userInput,
+        JSON.stringify(parsedHistory),
+      );
+      return c.json(data, 200);
+    } catch (e) {
+      const message = e instanceof Error ? e.message : "3Dオブジェクト生成失敗";
+      return c.json({ message }, 500);
+    }
+  },
+);
 
 export default app;

--- a/apps/backend/src/ai/schemas.ts
+++ b/apps/backend/src/ai/schemas.ts
@@ -23,11 +23,32 @@ export type AiOutputSchema = z.infer<typeof AiOutputSchema>;
 
 export const ConversationHistorySchema = z
   .object({
-    role: z.enum(["user", "assistant"]).openapi({ example: "user" }),
-    content: z.string().openapi({ example: "かわいい家つくって！" }),
+    role: z.enum(["user", "assistant"]).meta({ example: "user" }),
+    content: z.string().meta({ example: "かわいい家つくって！" }),
   })
   .array()
-  .openapi("会話履歴");
+  .meta({ description: "会話履歴" });
 export type ConversationHistorySchema = z.infer<
   typeof ConversationHistorySchema
 >;
+
+export const AiInputSchema = z.object({
+  userInput: z.string().min(1).meta({
+    example: "かわいい家つくって",
+    description: "ユーザー入力コメント",
+  }),
+  history: z
+    .string()
+    .optional()
+    .meta({
+      example: JSON.stringify([
+        { role: "user", content: "かわいい家つくって" },
+        {
+          role: "assistant",
+          content:
+            '{"chat": "かわいい家ができました！","name": "かわいい家","parts":[{~}]}',
+        },
+      ]),
+      description: "会話履歴(JSON文字列)",
+    }),
+});

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -1,5 +1,7 @@
 import { serve } from "@hono/node-server";
+import { Scalar } from "@scalar/hono-api-reference";
 import { Hono } from "hono";
+import { openAPIRouteHandler } from "hono-openapi";
 import ai from "./ai/createObject";
 
 const app = new Hono();
@@ -7,6 +9,41 @@ const app = new Hono();
 app.route("/ai", ai);
 
 app.get("/", (c) => c.text("Hello World!"));
+
+// OpenAPIドキュメントの設定
+app
+  .get(
+    "/openapi.json",
+    openAPIRouteHandler(app, {
+      documentation: {
+        info: {
+          title: "Hono",
+          version: "1.0.0",
+          description: "API for greeting users",
+        },
+      },
+      includeEmptyPaths: false,
+      excludeStaticFile: false,
+      exclude: "",
+      excludeMethods: [],
+      excludeTags: [],
+      defaultOptions: {
+        GET: {},
+        POST: {},
+        PUT: {},
+        DELETE: {},
+        PATCH: {},
+      },
+    }),
+  )
+  .get(
+    "/api/docs",
+    Scalar({
+      url: "/openapi.json",
+      theme: "alternate",
+      pageTitle: "BuildCha API Docs",
+    }),
+  );
 
 // ローカル開発用のnodeサーバーを起動
 const port = 8000;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,9 +26,9 @@ importers:
       '@hono/node-server':
         specifier: ^1.17.1
         version: 1.18.1(hono@4.9.0)
-      '@hono/zod-openapi':
-        specifier: ^1.1.0
-        version: 1.1.0(hono@4.9.0)(zod@4.0.17)
+      '@hono/zod-validator':
+        specifier: ^0.7.2
+        version: 0.7.2(hono@4.9.0)(zod@4.0.17)
       '@langchain/core':
         specifier: ^0.3.66
         version: 0.3.68(openai@5.12.2(zod@4.0.17))
@@ -38,12 +38,18 @@ importers:
       '@marplex/hono-azurefunc-adapter':
         specifier: ^1.0.1
         version: 1.0.1
+      '@scalar/hono-api-reference':
+        specifier: ^0.9.13
+        version: 0.9.13(hono@4.9.0)
       dotenv:
         specifier: ^17.2.1
         version: 17.2.1
       hono:
         specifier: ^4.8.4
         version: 4.9.0
+      hono-openapi:
+        specifier: 0.5.0-rc.1
+        version: 0.5.0-rc.1(@hono/standard-validator@0.1.4(@standard-schema/spec@1.0.0)(hono@4.9.0))(@standard-community/standard-json@0.3.0-rc.4(@standard-schema/spec@1.0.0)(@types/json-schema@7.0.15)(zod-to-json-schema@3.24.6(zod@4.0.17))(zod@4.0.17))(@standard-community/standard-openapi@0.2.0-rc.1(@standard-community/standard-json@0.3.0-rc.4(@standard-schema/spec@1.0.0)(@types/json-schema@7.0.15)(zod-to-json-schema@3.24.6(zod@4.0.17))(zod@4.0.17))(@standard-schema/spec@1.0.0)(openapi-types@12.1.3)(zod-openapi@5.3.1(zod@4.0.17))(zod@4.0.17))(hono@4.9.0)(openapi-types@12.1.3)(zod@4.0.17)
       langchain:
         specifier: ^0.3.30
         version: 0.3.30(@langchain/core@0.3.68(openai@5.12.2(zod@4.0.17)))(@langchain/google-genai@0.2.16(@langchain/core@0.3.68(openai@5.12.2(zod@4.0.17))))(openai@5.12.2(zod@4.0.17))
@@ -51,8 +57,11 @@ importers:
         specifier: ^4.20.3
         version: 4.20.3
       zod:
-        specifier: ^4.0.14
+        specifier: ^4.0.17
         version: 4.0.17
+      zod-openapi:
+        specifier: ^5.3.1
+        version: 5.3.1(zod@4.0.17)
     devDependencies:
       '@types/node':
         specifier: 18.x
@@ -137,11 +146,6 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
-
-  '@asteasolutions/zod-to-openapi@8.1.0':
-    resolution: {integrity: sha512-tQFxVs05J/6QXXqIzj6rTRk3nj1HFs4pe+uThwE95jL5II2JfpVXkK+CqkO7aT0Do5AYqO6LDrKpleLUFXgY+g==}
-    peerDependencies:
-      zod: ^4.0.0
 
   '@azure/functions@4.7.2':
     resolution: {integrity: sha512-5ps8yz4gn6oZSzeQbpUreWHFYl/YS03F1Sk/pz7YJphfctRcHuLF5tcrdm9AyRiYzja4Bkd63bju+g/E27opPQ==}
@@ -383,12 +387,11 @@ packages:
     peerDependencies:
       hono: ^4
 
-  '@hono/zod-openapi@1.1.0':
-    resolution: {integrity: sha512-S4jVR+A/jI4MA/RKJqmpjdHAN2l/EsqLnKHBv68x3WxV1NGVe3Sh7f6LV6rHEGYNHfiqpD75664A/erc+r9dQA==}
-    engines: {node: '>=16.0.0'}
+  '@hono/standard-validator@0.1.4':
+    resolution: {integrity: sha512-NPxSO9/Z1FFaJ34/0WJA0JoFRrVrJOG5P/i+PBJu7jCw9v0u8WmGiJu0zv+bTk1pjplBjjczAd59x2X50spRmQ==}
     peerDependencies:
-      hono: '>=4.3.6'
-      zod: ^4.0.0
+      '@standard-schema/spec': 1.0.0
+      hono: '>=3.9.0'
 
   '@hono/zod-validator@0.7.2':
     resolution: {integrity: sha512-ub5eL/NeZ4eLZawu78JpW/J+dugDAYhwqUIdp9KYScI6PZECij4Hx4UsrthlEUutqDDhPwRI0MscUfNkvn/mqQ==}
@@ -681,6 +684,72 @@ packages:
       react-native:
         optional: true
 
+  '@scalar/core@0.3.11':
+    resolution: {integrity: sha512-4O3mC29k2STz4quBHrpsl6czxi94F3dy8Ej/OPbELS2myKO4GoxromT0BiKSLPAThCnmJ0rqMZ7k9NsgzVjEgA==}
+    engines: {node: '>=20'}
+
+  '@scalar/hono-api-reference@0.9.13':
+    resolution: {integrity: sha512-79Gs+/2/FcqwZ3Lp0lsv3pFKHY1qBF2ONkfgh/gxRsd8Z+RZRTDBZafe7OConj+c4tHm0Zz3bKTKEV0OMQi/aA==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      hono: ^4.0.0
+
+  '@scalar/openapi-types@0.3.7':
+    resolution: {integrity: sha512-QHSvHBVDze3+dUwAhIGq6l1iOev4jdoqdBK7QpfeN1Q4h+6qpVEw3EEqBiH0AXUSh/iWwObBv4uMgfIx0aNZ5g==}
+    engines: {node: '>=20'}
+
+  '@scalar/types@0.2.11':
+    resolution: {integrity: sha512-SUZzGmoisWsYv33LmmT/ajvSlcl9ZDj9d5RncJ+wB9ZQ2l018xlfpDIH9Kdfo+6KCKQOe3LYLXfH4Lzm891Mag==}
+    engines: {node: '>=20'}
+
+  '@standard-community/standard-json@0.3.0-rc.4':
+    resolution: {integrity: sha512-AcFJqiYt0nj17VoReUkEhTq1JzM2oEytCyBoR0j09yHqrrHp1g6kvXoh+IyMWIeqWYVUml9wzr5VJrfxh69/8g==}
+    peerDependencies:
+      '@standard-schema/spec': ^1.0.0
+      '@types/json-schema': ^7.0.15
+      '@valibot/to-json-schema': ^1.3.0
+      arktype: ^2.1.20
+      effect: ^3.16.8
+      valibot: ^1.1.0
+      zod: ^3.25.0 || ^4.0.0
+      zod-to-json-schema: ^3.24.5
+    peerDependenciesMeta:
+      '@valibot/to-json-schema':
+        optional: true
+      arktype:
+        optional: true
+      effect:
+        optional: true
+      valibot:
+        optional: true
+      zod:
+        optional: true
+      zod-to-json-schema:
+        optional: true
+
+  '@standard-community/standard-openapi@0.2.0-rc.1':
+    resolution: {integrity: sha512-Gu/wshVs6Lid+fCo9yu5AT0bjcxLCBtOi6idmkGtT5wll9rLdvfOcvzklrklUQgdQX/Xj9AA3nIBllHdqLEBZg==}
+    peerDependencies:
+      '@standard-community/standard-json': ^0.3.0-rc.1
+      '@standard-schema/spec': ^1.0.0
+      arktype: ^2.1.20
+      openapi-types: ^12.1.3
+      valibot: ^1.1.0
+      zod: ^3.25.0 || ^4.0.0
+      zod-openapi: ^4
+    peerDependenciesMeta:
+      arktype:
+        optional: true
+      valibot:
+        optional: true
+      zod:
+        optional: true
+      zod-openapi:
+        optional: true
+
+  '@standard-schema/spec@1.0.0':
+    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
+
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
 
@@ -780,6 +849,9 @@ packages:
 
   '@types/draco3d@1.4.10':
     resolution: {integrity: sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
   '@types/node@18.19.122':
     resolution: {integrity: sha512-yzegtT82dwTNEe/9y+CM8cgb42WrUfMMCg2QqSddzO1J6uPmBD7qKCZ7dOHZP2Yrpm/kb0eqdNMn2MUyEiqBmA==}
@@ -1085,6 +1157,35 @@ packages:
   hls.js@1.6.7:
     resolution: {integrity: sha512-QW2fnwDGKGc9DwQUGLbmMOz8G48UZK7PVNJPcOUql1b8jubKx4/eMHNP5mGqr6tYlJNDG1g10Lx2U/qPzL6zwQ==}
 
+  hono-openapi@0.5.0-rc.1:
+    resolution: {integrity: sha512-MzlMzJsO0qehEuXa1KD/gL3xFjH5Enn02VcO/A3OpUpn26V7V0Hs0dApP8bqN9eEyUr1yI55R2tGS680k8sALA==}
+    peerDependencies:
+      '@hono/standard-validator': ^0.1.2
+      '@sinclair/typebox': ^0.34.9
+      '@standard-community/standard-json': ^0.3.0-rc.1
+      '@standard-community/standard-openapi': ^0.2.0-rc.1
+      arktype: ^2.0.0
+      effect: ^3.16.12
+      hono: ^4.8.3
+      openapi-types: ^12.1.3
+      valibot: ^1.0.0-beta.9
+      zod: ^3.23.8
+    peerDependenciesMeta:
+      '@hono/standard-validator':
+        optional: true
+      '@sinclair/typebox':
+        optional: true
+      arktype:
+        optional: true
+      effect:
+        optional: true
+      hono:
+        optional: true
+      valibot:
+        optional: true
+      zod:
+        optional: true
+
   hono@4.9.0:
     resolution: {integrity: sha512-JAUc4Sqi3lhby2imRL/67LMcJFKiCu7ZKghM7iwvltVZzxEC5bVJCsAa4NTnSfmWGb+N2eOVtFE586R+K3fejA==}
     engines: {node: '>=16.9.0'}
@@ -1379,6 +1480,11 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@5.1.5:
+    resolution: {integrity: sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==}
+    engines: {node: ^18 || >=20}
+    hasBin: true
+
   next@15.3.5:
     resolution: {integrity: sha512-RkazLBMMDJSJ4XZQ81kolSpwiCt907l0xcgcpF4xC2Vml6QVcPNXW0NQRwQ80FFtSn7UM52XN0anaw8TEJXaiw==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
@@ -1418,9 +1524,6 @@ packages:
 
   openapi-types@12.1.3:
     resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
-
-  openapi3-ts@4.5.0:
-    resolution: {integrity: sha512-jaL+HgTq2Gj5jRcfdutgRGLosCy/hT8sQf6VOy+P+g36cZOjI1iukdPnijC+4CmeRzg/jEllJUboEic2FhxhtQ==}
 
   p-finally@1.0.0:
     resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
@@ -1778,10 +1881,19 @@ packages:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
 
+  zod-openapi@5.3.1:
+    resolution: {integrity: sha512-lRb4p4+WAhLGBvQCQf5SFxeZtnzO5m3GmCT4IDjOzGNlZFiVOuey9rWN+EVEDSVJC59B54tP2gxah1wVUplONw==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      zod: ^3.25.74 || ^4.0.0
+
   zod-to-json-schema@3.24.6:
     resolution: {integrity: sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==}
     peerDependencies:
       zod: ^3.24.1
+
+  zod@3.24.1:
+    resolution: {integrity: sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==}
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -1830,11 +1942,6 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.12
       '@jridgewell/trace-mapping': 0.3.29
-
-  '@asteasolutions/zod-to-openapi@8.1.0(zod@4.0.17)':
-    dependencies:
-      openapi3-ts: 4.5.0
-      zod: 4.0.17
 
   '@azure/functions@4.7.2':
     dependencies:
@@ -1974,13 +2081,11 @@ snapshots:
     dependencies:
       hono: 4.9.0
 
-  '@hono/zod-openapi@1.1.0(hono@4.9.0)(zod@4.0.17)':
+  '@hono/standard-validator@0.1.4(@standard-schema/spec@1.0.0)(hono@4.9.0)':
     dependencies:
-      '@asteasolutions/zod-to-openapi': 8.1.0(zod@4.0.17)
-      '@hono/zod-validator': 0.7.2(hono@4.9.0)(zod@4.0.17)
+      '@standard-schema/spec': 1.0.0
       hono: 4.9.0
-      openapi3-ts: 4.5.0
-      zod: 4.0.17
+    optional: true
 
   '@hono/zod-validator@0.7.2(hono@4.9.0)(zod@4.0.17)':
     dependencies:
@@ -2246,6 +2351,44 @@ snapshots:
       - '@types/react'
       - immer
 
+  '@scalar/core@0.3.11':
+    dependencies:
+      '@scalar/types': 0.2.11
+
+  '@scalar/hono-api-reference@0.9.13(hono@4.9.0)':
+    dependencies:
+      '@scalar/core': 0.3.11
+      hono: 4.9.0
+
+  '@scalar/openapi-types@0.3.7':
+    dependencies:
+      zod: 3.24.1
+
+  '@scalar/types@0.2.11':
+    dependencies:
+      '@scalar/openapi-types': 0.3.7
+      nanoid: 5.1.5
+      zod: 3.24.1
+
+  '@standard-community/standard-json@0.3.0-rc.4(@standard-schema/spec@1.0.0)(@types/json-schema@7.0.15)(zod-to-json-schema@3.24.6(zod@4.0.17))(zod@4.0.17)':
+    dependencies:
+      '@standard-schema/spec': 1.0.0
+      '@types/json-schema': 7.0.15
+    optionalDependencies:
+      zod: 4.0.17
+      zod-to-json-schema: 3.24.6(zod@4.0.17)
+
+  '@standard-community/standard-openapi@0.2.0-rc.1(@standard-community/standard-json@0.3.0-rc.4(@standard-schema/spec@1.0.0)(@types/json-schema@7.0.15)(zod-to-json-schema@3.24.6(zod@4.0.17))(zod@4.0.17))(@standard-schema/spec@1.0.0)(openapi-types@12.1.3)(zod-openapi@5.3.1(zod@4.0.17))(zod@4.0.17)':
+    dependencies:
+      '@standard-community/standard-json': 0.3.0-rc.4(@standard-schema/spec@1.0.0)(@types/json-schema@7.0.15)(zod-to-json-schema@3.24.6(zod@4.0.17))(zod@4.0.17)
+      '@standard-schema/spec': 1.0.0
+      openapi-types: 12.1.3
+    optionalDependencies:
+      zod: 4.0.17
+      zod-openapi: 5.3.1(zod@4.0.17)
+
+  '@standard-schema/spec@1.0.0': {}
+
   '@swc/counter@0.1.3': {}
 
   '@swc/helpers@0.5.15':
@@ -2327,6 +2470,8 @@ snapshots:
   '@tweenjs/tween.js@23.1.3': {}
 
   '@types/draco3d@1.4.10': {}
+
+  '@types/json-schema@7.0.15': {}
 
   '@types/node@18.19.122':
     dependencies:
@@ -2621,6 +2766,16 @@ snapshots:
 
   hls.js@1.6.7: {}
 
+  hono-openapi@0.5.0-rc.1(@hono/standard-validator@0.1.4(@standard-schema/spec@1.0.0)(hono@4.9.0))(@standard-community/standard-json@0.3.0-rc.4(@standard-schema/spec@1.0.0)(@types/json-schema@7.0.15)(zod-to-json-schema@3.24.6(zod@4.0.17))(zod@4.0.17))(@standard-community/standard-openapi@0.2.0-rc.1(@standard-community/standard-json@0.3.0-rc.4(@standard-schema/spec@1.0.0)(@types/json-schema@7.0.15)(zod-to-json-schema@3.24.6(zod@4.0.17))(zod@4.0.17))(@standard-schema/spec@1.0.0)(openapi-types@12.1.3)(zod-openapi@5.3.1(zod@4.0.17))(zod@4.0.17))(hono@4.9.0)(openapi-types@12.1.3)(zod@4.0.17):
+    dependencies:
+      '@standard-community/standard-json': 0.3.0-rc.4(@standard-schema/spec@1.0.0)(@types/json-schema@7.0.15)(zod-to-json-schema@3.24.6(zod@4.0.17))(zod@4.0.17)
+      '@standard-community/standard-openapi': 0.2.0-rc.1(@standard-community/standard-json@0.3.0-rc.4(@standard-schema/spec@1.0.0)(@types/json-schema@7.0.15)(zod-to-json-schema@3.24.6(zod@4.0.17))(zod@4.0.17))(@standard-schema/spec@1.0.0)(openapi-types@12.1.3)(zod-openapi@5.3.1(zod@4.0.17))(zod@4.0.17)
+      openapi-types: 12.1.3
+    optionalDependencies:
+      '@hono/standard-validator': 0.1.4(@standard-schema/spec@1.0.0)(hono@4.9.0)
+      hono: 4.9.0
+      zod: 4.0.17
+
   hono@4.9.0: {}
 
   husky@9.1.7: {}
@@ -2841,6 +2996,8 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  nanoid@5.1.5: {}
+
   next@15.3.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
     dependencies:
       '@next/env': 15.3.5
@@ -2880,10 +3037,6 @@ snapshots:
     optional: true
 
   openapi-types@12.1.3: {}
-
-  openapi3-ts@4.5.0:
-    dependencies:
-      yaml: 2.8.1
 
   p-finally@1.0.0: {}
 
@@ -3229,9 +3382,20 @@ snapshots:
       y18n: 5.0.8
       yargs-parser: 21.1.1
 
+  zod-openapi@5.3.1(zod@4.0.17):
+    dependencies:
+      zod: 4.0.17
+
   zod-to-json-schema@3.24.6(zod@3.25.76):
     dependencies:
       zod: 3.25.76
+
+  zod-to-json-schema@3.24.6(zod@4.0.17):
+    dependencies:
+      zod: 4.0.17
+    optional: true
+
+  zod@3.24.1: {}
 
   zod@3.25.76: {}
 


### PR DESCRIPTION
code rabbit動いてくれないので手書き（雑です）

## 実装内容
- Zod OpenAPIからHono OpenAPIへの移行
- Scalarでドキュメントの表示 (機能的にはswaggerと同じようなもの)
  - `/api/docs`で表示

https://github.com/buildccho/BuildCha/pull/17 こちらへのPRです