### PR TITLE
単体写真をR2にアップロードする機能を追加

### DIFF
--- a/apps/backend/src/routes/r2.ts
+++ b/apps/backend/src/routes/r2.ts
@@ -15,74 +15,135 @@ const uploadFunction = (image: File, path: string) => {
 
 const app = new Hono<{
   Bindings: CloudflareBindings;
-}>().post(
-  "/objectImages",
-  describeRoute({
-    description: "3Dオブジェクト画像アップロードエンドポイント",
-    tags: ["R2"],
-    responses: {
-      200: {
-        description: "アップロード成功",
-        content: {
-          "application/json": {
-            schema: resolver(
-              z.object({
-                message: z.string().meta({ example: "アップロード成功" }),
-              }),
-            ),
+}>()
+  .post(
+    "/objectImages",
+    describeRoute({
+      description: "3Dオブジェクト画像アップロードエンドポイント",
+      tags: ["R2"],
+      responses: {
+        200: {
+          description: "アップロード成功",
+          content: {
+            "application/json": {
+              schema: resolver(
+                z.object({
+                  message: z.string().meta({ example: "アップロード成功" }),
+                }),
+              ),
+            },
+          },
+        },
+        400: {
+          description: "バリデーションエラー",
+          content: {
+            "application/json": {
+              schema: resolver(ErrorSchema),
+            },
+          },
+        },
+        500: {
+          description: "サーバーエラー",
+          content: {
+            "application/json": {
+              schema: resolver(ErrorSchema),
+            },
           },
         },
       },
-      400: {
-        description: "バリデーションエラー",
-        content: {
-          "application/json": {
-            schema: resolver(ErrorSchema),
-          },
-        },
-      },
-      500: {
-        description: "サーバーエラー",
-        content: {
-          "application/json": {
-            schema: resolver(ErrorSchema),
-          },
-        },
-      },
-    },
-  }),
-  validator(
-    "form",
-    z.object({
-      topView: z.file().mime("image/png").meta({ example: "上面画像" }),
-      bottomView: z.file().mime("image/png").meta({ example: "下面画像" }),
-      leftView: z.file().mime("image/png").meta({ example: "左面画像" }),
-      rightView: z.file().mime("image/png").meta({ example: "右面画像" }),
-      frontView: z.file().mime("image/png").meta({ example: "前面画像" }),
-      backView: z.file().mime("image/png").meta({ example: "背面画像" }),
     }),
-  ),
-  async (c) => {
-    try {
-      const { topView, bottomView, leftView, rightView, frontView, backView } =
-        c.req.valid("form");
-      //NOTE: 6枚同時だとタイムアウトする可能性があるため、3枚ずつに分けてアップロード
-      await Promise.all([
-        uploadFunction(topView as File, "objectImages/topView"),
-        uploadFunction(bottomView as File, "objectImages/bottomView"),
-        uploadFunction(leftView as File, "objectImages/leftView"),
-      ]);
-      await Promise.all([
-        uploadFunction(rightView as File, "objectImages/rightView"),
-        uploadFunction(frontView as File, "objectImages/frontView"),
-        uploadFunction(backView as File, "objectImages/backView"),
-      ]);
-      return c.json({ message: "アップロード成功" }, 200);
-    } catch (error) {
-      console.error("アップロードエラー:", error);
-      return c.json({ message: "サーバーエラーが発生しました。" }, 500);
-    }
-  },
-);
+    validator(
+      "form",
+      z.object({
+        topView: z.file().mime("image/png").meta({ example: "上面画像" }),
+        bottomView: z.file().mime("image/png").meta({ example: "下面画像" }),
+        leftView: z.file().mime("image/png").meta({ example: "左面画像" }),
+        rightView: z.file().mime("image/png").meta({ example: "右面画像" }),
+        frontView: z.file().mime("image/png").meta({ example: "前面画像" }),
+        backView: z.file().mime("image/png").meta({ example: "背面画像" }),
+      }),
+    ),
+    async (c) => {
+      try {
+        const {
+          topView,
+          bottomView,
+          leftView,
+          rightView,
+          frontView,
+          backView,
+        } = c.req.valid("form");
+        //NOTE: 6枚同時だとタイムアウトする可能性があるため、3枚ずつに分けてアップロード
+        await Promise.all([
+          uploadFunction(topView as File, "objectImages/topView"),
+          uploadFunction(bottomView as File, "objectImages/bottomView"),
+          uploadFunction(leftView as File, "objectImages/leftView"),
+        ]);
+        await Promise.all([
+          uploadFunction(rightView as File, "objectImages/rightView"),
+          uploadFunction(frontView as File, "objectImages/frontView"),
+          uploadFunction(backView as File, "objectImages/backView"),
+        ]);
+        return c.json({ message: "アップロード成功" }, 200);
+      } catch (error) {
+        console.error("アップロードエラー:", error);
+        return c.json({ message: "サーバーエラーが発生しました。" }, 500);
+      }
+    },
+  )
+  .post(
+    "/image/:key",
+    describeRoute({
+      description: "単一画像アップロードエンドポイント",
+      tags: ["R2"],
+      responses: {
+        200: {
+          description: "アップロード成功",
+          content: {
+            "application/json": {
+              schema: resolver(
+                z.object({
+                  message: z.string().meta({ example: "アップロード成功" }),
+                }),
+              ),
+            },
+          },
+        },
+        400: {
+          description: "バリデーションエラー",
+          content: {
+            "application/json": {
+              schema: resolver(ErrorSchema),
+            },
+          },
+        },
+        500: {
+          description: "サーバーエラー",
+          content: {
+            "application/json": {
+              schema: resolver(ErrorSchema),
+            },
+          },
+        },
+      },
+    }),
+    validator(
+      "form",
+      z.object({
+        image: z.file().mime("image/png").meta({ example: "アップロード画像" }),
+      }),
+    ),
+    async (c) => {
+      try {
+        const { image } = c.req.valid("form");
+        const { key } = c.req.param();
+        await uploadFunction(image as File, key);
+        return c.json({ message: "アップロード成功" }, 200);
+      } catch (error) {
+        console.error("アップロードエラー:", error);
+        return c.json({ message: "サーバーエラーが発生しました。" }, 500);
+      }
+    },
+  );
 
 export default app;


### PR DESCRIPTION
close #91 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 画像アップロード機能を2つの専用エンドポイントに分割しました
  * 複数の画像を効率的にアップロードできるエンドポイント（6つのビュー画像に対応）を追加
  * キーを指定して単一の画像をアップロードする新しいエンドポイントを追加
  * エラーハンドリングを強化し、より詳細なレスポンス情報を提供

<!-- end of auto-generated comment: release notes by coderabbit.ai -->